### PR TITLE
(maint) Expand test coverage to include Debian 10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,15 +15,18 @@ jobs:
     strategy:
       matrix:
         os:
-          - ['almalinux', '8', 'x86_64']                           
-          - ['almalinux', '9', 'x86_64']                           
-          - ['debian', '11', 'x86_64']                             
-          - ['debian', '12', 'x86_64']                             
+          - ['almalinux', '8', 'x86_64']
+          - ['almalinux', '9', 'x86_64']
+          - ['debian', '10', 'x86_64']
+          - ['debian', '11', 'x86_64']
+          - ['debian', '12', 'x86_64']
           # debian 13 is not released yet, but we can get dailies..
-          - ['debian', '13', 'x86_64', 'daily-latest']             
-          - ['rocky', '8', 'x86_64']                               
-          - ['rocky', '9', 'x86_64']                               
-          - ['ubuntu', '22.04', 'x86_64']                          
+          - ['debian', '13', 'x86_64', 'daily-latest']
+          - ['rocky', '8', 'x86_64']
+          - ['rocky', '9', 'x86_64']
+          - ['ubuntu', '18.04', 'x86_64']
+          - ['ubuntu', '20.04', 'x86_64']
+          - ['ubuntu', '22.04', 'x86_64']
           - ['ubuntu', '24.04', 'x86_64']
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The action can created nested vms for any OS supported by
 * Almalinux 9, 8
 * Debian 13, 12, 11, 10
 * Rocky 9, 8
-* Ubuntu 24.04, 22.04
+* Ubuntu 24.04, 22.04, 20.04, 18.04
 
 ## Usage
 


### PR DESCRIPTION
and Ubuntu 18.04, 20.04. Still have openvox packages released for them, atm.