### PR TITLE
(maint) Allow skipping checkout for kvm_automation_tooling module

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -125,7 +125,7 @@ runs:
       uses: actions/checkout@v4
       with:
         repository: 'jpartlow/kvm_automation_tooling'
-        ref: 'v1'
+        ref: 'v2'
         path: 'kvm_automation_tooling'
     - name: Install Terraform
       shell: bash
@@ -199,10 +199,17 @@ runs:
           "vms": ${VMS},
           "install_openvox": ${INSTALL_OPENVOX},
           "install_openvox_params": {
-            "openvox_collection": "${OPENVOX_COLLECTION}",
-            "openvox_version": "${OPENVOX_VERSION}",
-            "openvox_released": ${OPENVOX_RELEASED},
-            "openvox_artifacts_url": "${OPENVOX_ARTIFACTS_URL}"
+            "openvox_agent_params": {
+              "openvox_collection": "${OPENVOX_COLLECTION}",
+              "openvox_version": "${OPENVOX_VERSION}",
+              "openvox_released": ${OPENVOX_RELEASED},
+              "openvox_artifacts_url": "${OPENVOX_ARTIFACTS_URL}"
+            },
+            "install_defaults": {
+              "openvox_version": "latest",
+              "openvox_collection": "${OPENVOX_COLLECTION}",
+              "openvox_released": true
+            }
           }
         }
         EOF


### PR DESCRIPTION
The kvm_automation_tooling::standup_cluster plan changed install_openvox_params to allow for openvox-agent, openvox-server and openvoxdb versions in https://github.com/jpartlow/kvm_automation_tooling/pull/23.

Those changes are tagged v2.

We're only providing for setting openvox_agent version, and the default collection in nested_vms, but regardless the syntax of install_openvox_params needs to be updated to match the new structure.

---

Also provides a checkout flag. When checkout=false the action will use the kvm_automation_tooling/ checkout provided by the calling workflow. This is used by kvm_automation_tooling itself to test compatibilty of newer branches with nested_vms.