### PR TITLE
(maint) Drop debian-10 from testing matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,6 @@ jobs:
         os:
           - ['almalinux', '8', 'x86_64']
           - ['almalinux', '9', 'x86_64']
-          - ['debian', '10', 'x86_64']
           - ['debian', '11', 'x86_64']
           - ['debian', '12', 'x86_64']
           # debian 13 is not released yet, but we can get dailies..


### PR DESCRIPTION
Debian 10 was eol last year. Packages have now been dropped from the main deb.debian.org mirrors and are now available only from archive.debian.org, so the images no longer work correctly.